### PR TITLE
Fix call to deprecated Parser::disableCache()

### DIFF
--- a/SimpleBreadcrumb.php
+++ b/SimpleBreadcrumb.php
@@ -150,7 +150,7 @@ class SimpleBreadCrumb
 
 		$breadcrumb = array();
 
-		$parser->disableCache();
+		$parser->getOutput()->updateCacheExpiry(0);
 
 		// Add current page, with self link if activated
 		if (self::$selfLink)


### PR DESCRIPTION
In MW 1.35, Parser::disableCache() was deprecated and the suggested replacement is what I inserted in its place.

See https://doc.wikimedia.org/mediawiki-core/REL1_33/php/classParser.html#a38972c4088c6293007f09f0d3f9b7120